### PR TITLE
windows: quote the arguments manually

### DIFF
--- a/src/ask-pass-trampoline.c
+++ b/src/ask-pass-trampoline.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 #include <errno.h>
 
 #ifdef WINDOWS
@@ -14,6 +15,90 @@
 #else
   // execv and friends on POSIX
   #include <unistd.h>
+#endif
+
+#ifdef WINDOWS
+/*
+ * See "Parsing C++ Command-Line Arguments" at Microsoft's Docs:
+ * https://docs.microsoft.com/en-us/cpp/cpp/parsing-cpp-command-line-arguments
+ */
+static char *quote(char *string)
+{
+  const char *p;
+  int needs_quotes = !*string; /* an empty string always needs to be quoted */
+  size_t len = 0;
+
+  for (p = string; *p; p++, len++) {
+    if (*p == '"')
+      len++;
+    else if (strchr(" \t\r\n*?{'", *p))
+      needs_quotes = 1;
+    else if (*p == '\\') {
+      const char *end = p;
+      while (end[1] == '\\')
+	end++;
+      len += end - p;
+      if (end[1] == '"')
+	len += end - p + 1;
+      p = end;
+    }
+  }
+
+  if (!needs_quotes && len == p - string)
+    return string;
+
+  char *result = malloc((len + 3) * sizeof(WCHAR)), *q = result;
+  *(q++) = '"';
+  for (p = string; *p; p++) {
+    if (*p == '"')
+      *(q++) = '\\';
+    else if (*p == '\\') {
+      const char *end = p;
+      while (end[1] == '\\')
+	end++;
+      if (end != p) {
+	memcpy(q, p, end - p);
+	q += end - p;
+      }
+      if (end[1] == '"') {
+	memcpy(q, p, end - p + 1);
+	q += end - p + 1;
+      }
+      p = end;
+    }
+    *(q++) = *p;
+  }
+  *(q++) = '\"';
+  *q = '\0';
+
+  return result;
+}
+
+/*
+ * The `_spawnv()` function does not quote the arguments properly. So let's do this manually.
+ */
+static int windows_execl(const char *path, ...)
+{
+  va_list params;
+  int i = 0, nr;
+#define MAX_ARGS 64
+  char *argv[MAX_ARGS + 1], *quoted[MAX_ARGS + 1];
+
+  va_start(params, path);
+  while (i < MAX_ARGS && (argv[i] = va_arg(params, char *)))
+    quoted[i] = quote(argv[i++]);
+  nr = i;
+  quoted[nr] = NULL;
+
+  int err = _spawnv(_P_WAIT, path, quoted);
+
+  for (i = 0; i < nr; i++)
+    if (argv[i] != quoted[i])
+      free(quoted[i]);
+
+  return err;
+}
+#define execl windows_execl
 #endif
 
 int main(int argc, char **argv)
@@ -40,20 +125,7 @@ int main(int argc, char **argv)
   putenv("ELECTRON_RUN_AS_NODE=1");
   putenv("ELECTRON_NO_ATTACH_CONSOLE=1");
 
-  #if WINDOWS
-    // I don't know what I'm doing!
-    char quotedDesktopPath[MAX_PATH];
-    strncpy(quotedDesktopPath, desktopPath, sizeof(quotedDesktopPath));
-    PathQuoteSpaces(quotedDesktopPath);
-
-    char quotedDesktopAskPassScriptPath[MAX_PATH];
-    strncpy(quotedDesktopAskPassScriptPath, desktopAskPassScriptPath, sizeof(quotedDesktopAskPassScriptPath));
-    PathQuoteSpaces(quotedDesktopAskPassScriptPath);
-
-    err = _spawnl(_P_WAIT, desktopPath, quotedDesktopPath, desktopAskPassScriptPath, argv[1], NULL);
-  #else
-    err = execl(desktopPath, desktopPath, desktopAskPassScriptPath, argv[1], NULL);
-  #endif
+  err = execl(desktopPath, desktopPath, desktopAskPassScriptPath, argv[1], NULL);
 
   if (err != 0) {
     fprintf(stderr, "ERROR: Failed to launch \"%s\": %s\n", desktopPath, strerror(errno));


### PR DESCRIPTION
This borrows the strategy from Git for Windows' `git-credential-helper-selector` to quote the arguments manually (as needed). That avoids the implicit `MAX_PATH` limit of `PathQuoteSpaces()` and also makes it possible to quote a couple more special characters.