### PR TITLE
Wait until process streams have closed

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ function run(args, options) {
     cp.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
     cp.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
 
-    cp.on("exit", (code) => {
+    cp.on("close", (code) => {
       resolve({ code, stdout, stderr });
     });
   });


### PR DESCRIPTION
Fixed a race condition that caused tests to fail predominantly on Linux